### PR TITLE
Amend plutus.py to use new get_balance function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An automated bitcoin wallet collider that brute forces random wallet addresses w
 
 - [X] Prevent 429 errors from slowing down program
 
+- Problems sharing 429 errors across threads, please don't use this version!!!
+
 - [ ] Create a GUI
 
 <br/>

--- a/test.py
+++ b/test.py
@@ -1,0 +1,59 @@
+import requests
+# For some weird exceptions that might occur
+from requests.exceptions import *
+import json
+import sys
+
+def get_balance(address):
+	
+	global blocked
+	global global_counter
+
+	# Where do we get the response.status_code for 429?
+	# A valid response or in an exception?
+	if not blocked:
+		response = None
+		try:
+			response = requests.get("https://blockchain.info/rawaddr/{}".format(address), timeout=0.005)
+			global_counter += 1
+			if response.status_code == 429:
+				blocked = True
+				print("We're blocked after {} requests.".format(global_counter))
+				for key, value in response.headers.iteritems():
+					print("\t{} : {}".format(key, value))
+				return -1
+			balance = 0
+			try:
+				balance = response.json()['final_balance']
+			except:
+				print("Probably a JSONDecodeError, resuming...")
+				pass
+			return int(balance)
+		except (ConnectionError, RequestException, HTTPError, ProxyError, SSLError, Timeout, ConnectTimeout, ReadTimeout, InvalidHeader, ChunkedEncodingError, ContentDecodingError) as e:
+			print("Some exception caught: {}".format(e))
+			for key, value in response.headers.iteritems():
+    				print("\t{} : {}".format(key, value))
+			return -1
+
+
+if __name__ == '__main__':
+	
+	if len(sys.argv) != 2:
+		print("Usage: {} FileWithBitcoinAddresses")
+		exit(1)
+
+	blocked = False
+	address_file = sys.argv[1]
+	addrs = []
+	global_counter = 0
+
+	with open(address_file, 'r') as fp:
+		addrs = [a.rstrip() for a in fp.readlines()]
+
+	for a in addrs:
+		bal = get_balance(a)
+		if bal < 0:
+			print("Hrm...")
+			exit(1)
+		else:
+			print("Balance of {} is {}".format(a, bal))


### PR DESCRIPTION
Plutus now has three balance functions that return balances in Satoshis,
which should help resolve issues such as HTTP 429 "slow your mojo".

When exceptions are caught, these are assumed to be the server blocking
us for some reason, so the global variables for each balance functions are
set to True.  This still needs some testing; the globals may not be set, but
after a 429, it's possible that short break will allow us to continue calling
the API.

When they are all set to False, then Plutus fails to deliver balances.

Working on a fix for this in case a server sends a Retry-After HTTP header,
so we can keep an eye on a timer and then resume using the balance API
call.

Occasionally weird errors happen, so an exception is caught and it's
simply ignored without further ado if the server returns strange JSON
that can't be parsed, or returns encoding which can't be detected.